### PR TITLE
Add simple audit fields on Upgrade

### DIFF
--- a/api/upgrades.js
+++ b/api/upgrades.js
@@ -53,6 +53,7 @@ const ITEM_STATUS_SOQL = `
 
 const SELECT_ALL = `
     SELECT u.id, u.status, u.start_time, u.created_by, u.description, u.org_group_id, u.parent_id,
+        			u.activated_by, u.activated_date,
     CAST (SUM(i.total_job_count) AS INTEGER) total_job_count,
     ${ITEM_STATUS_SOQL}    
     FROM upgrade u
@@ -61,7 +62,8 @@ const SELECT_ALL = `
 const GROUP_BY_ALL = `GROUP BY u.id, u.start_time, u.created_by, u.description`;
 
 const SELECT_ONE = `
-    SELECT u.id, u.status, u.start_time, u.created_by, u.description, u.org_group_id, u.parent_id, u.comment,
+    SELECT u.id, u.status, u.start_time, u.created_by, u.description, u.org_group_id, u.parent_id, 
+    			u.activated_by, u.activated_date, u.comment,
     CAST (SUM(i.total_job_count) AS INTEGER) total_job_count,
 	${ITEM_STATUS_SOQL}
     FROM upgrade u
@@ -671,7 +673,9 @@ async function activateUpgrade(id, username, job = {postMessage: msg => logger.i
 	
 	await activateAvailableUpgradeItems(id, username, job);
 	upgrade.status = UpgradeStatus.Active;
-	await db.update(`UPDATE upgrade SET status = $1 WHERE id = $2`, [upgrade.status, id]);
+	upgrade.activated_by = username;
+	upgrade.activated_date = new Date().toISOString();
+	await db.update(`UPDATE upgrade SET status = $2, activated_by = $3, activated_date = $4 WHERE id = $1`, [id, upgrade.status, upgrade.activated_by, upgrade.activated_date]);
 	admin.emit(admin.Events.UPGRADE, upgrade);
 }
 

--- a/client/src/upgrades/UpgradeCard.js
+++ b/client/src/upgrades/UpgradeCard.js
@@ -38,8 +38,9 @@ export default class extends React.Component {
 			},
 			{Header: "When", id: "when", accessor: d => moment(d.start_time).fromNow(), clickable: true, sortable: false},
 			{Header: "Created By", accessor: "created_by", sortable: true},
-			{Header: "Activated By", accessor: "activated_by", sortable: true},
-			{Header: "Activated On", id: "activated_date", accessor: d => moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A"), sortable: true}
+			{Header: "Activated By", id: "activated_by", accessor: d => d.activated_by || 'Pending', sortable: true},
+			{Header: "Activated On", id: "activated_date", accessor: d => d.activated_date ?
+					moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A") : 'Pending', sortable: true}
 		];
 
 		const actions = [

--- a/client/src/upgrades/UpgradeCard.js
+++ b/client/src/upgrades/UpgradeCard.js
@@ -26,6 +26,8 @@ export default class extends React.Component {
 		let columns = [
 			{Header: "Number", accessor: "id", minWidth: 60, sortable: true, clickable: true},
 			{Header: "Description", accessor: "description", minWidth: 300, clickable: true},
+			{Header: "Job Count", accessor: "total_job_count", sortable: true},
+			{Header: "Status", accessor: "item_status", sortable: true},
 			{
 				Header: "Scheduled Start Time",
 				maxWidth: 200,
@@ -36,7 +38,8 @@ export default class extends React.Component {
 			},
 			{Header: "When", id: "when", accessor: d => moment(d.start_time).fromNow(), clickable: true, sortable: false},
 			{Header: "Created By", accessor: "created_by", sortable: true},
-			{Header: "Status", accessor: "item_status", sortable: true}
+			{Header: "Activated By", accessor: "activated_by", sortable: true},
+			{Header: "Activated On", id: "activated_date", accessor: d => moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A"), sortable: true}
 		];
 
 		const actions = [

--- a/client/src/upgrades/UpgradeHome.js
+++ b/client/src/upgrades/UpgradeHome.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import {CSVDownload} from 'react-csv';
 
 import {HomeHeader} from '../components/PageHeader';
 import UpgradeList from "./UpgradeList";
@@ -27,6 +27,7 @@ export default class extends React.Component {
 		this.purgeHandler = this.purgeHandler.bind(this);
 		this.openAnalysisWindow = this.openAnalysisWindow.bind(this);
 		this.closeAnalysisWindow = this.closeAnalysisWindow.bind(this);
+		this.exportHandler = this.exportHandler.bind(this);
 	}
 
 	// Lifecycle
@@ -42,10 +43,11 @@ export default class extends React.Component {
 				disabled: user.read_only || selected.size === 0,
 				detail: user.read_only ? Messages.READ_ONLY_USER : "",
 				handler: this.purgeHandler},
-      {label: "Analyze", group: "selectable",  
-        spinning: this.state.addingToGroup, 
-        disabled: selected.size === 0, 
-        handler: this.openAnalysisWindow}
+      		{label: "Analyze", group: "selectable",
+				spinning: this.state.addingToGroup,
+				disabled: selected.size === 0,
+				handler: this.openAnalysisWindow},
+			{label: "Export", handler: this.exportHandler}
 		];
 
 		return (
@@ -58,6 +60,7 @@ export default class extends React.Component {
 					<AnalysisWindow title="Upgrade Analysis" stats={this.state.stats}
 					onClose={this.closeAnalysisWindow}/> : ""
 				}
+				{this.state.isExporting ? <CSVDownload data={this.state.filtered} separator={"\t"} target="_blank" /> : ""}
 			</div>
 		);
 	}
@@ -80,7 +83,7 @@ export default class extends React.Component {
 	}
 
 	filterHandler(filtered, filterColumns, itemCount) {
-		this.setState({itemCount, filterColumns});
+		this.setState({filtered, itemCount, filterColumns});
 	}
 	
 	applySavedFilter(filterColumns) {
@@ -119,7 +122,7 @@ export default class extends React.Component {
 		this.setState({showStats: null});
 	}
 
-    groupStatsByPackage(stats){
+    groupStatsByPackage(stats) {
 		let items = [];
 		for (const stat of stats) {
 			const data = {};
@@ -134,5 +137,10 @@ export default class extends React.Component {
 			}
 		}
 		return items;
+	}
+
+	exportHandler() {
+		this.setState({isExporting: true});
+		setTimeout(function() {this.setState({isExporting: false})}.bind(this), 1000);
 	}
 }

--- a/client/src/upgrades/UpgradeList.js
+++ b/client/src/upgrades/UpgradeList.js
@@ -30,8 +30,9 @@ export default class extends React.Component {
 			},
 			{Header: "When", id: "when", accessor: d => moment(d.start_time).fromNow(), clickable: true, sortable: false},
 			{Header: "Created By", accessor: "created_by", sortable: true},
-			{Header: "Activated By", accessor: "activated_by", sortable: true},
-			{Header: "Activated On", id: "activated_date", accessor: d => moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A"), sortable: true}
+			{Header: "Activated By", id: "activated_by", accessor: d => d.activated_by || 'Pending', sortable: true},
+			{Header: "Activated On", id: "activated_date", accessor: d => d.activated_date ?
+					moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A") : 'Pending', sortable: true}
 		];
 		return (
 			<div className="slds-color__background_gray-1">

--- a/client/src/upgrades/UpgradeList.js
+++ b/client/src/upgrades/UpgradeList.js
@@ -18,6 +18,8 @@ export default class extends React.Component {
 		let columns = [
 			{Header: "Number", accessor: "id", minWidth: 60, sortable: true, clickable: true},
 			{Header: "Description", accessor: "description", minWidth: 300, clickable: true},
+			{Header: "Job Count", accessor: "total_job_count", sortable: true},
+			{Header: "Status", accessor: "item_status", sortable: true},
 			{
 				Header: "Scheduled Start Time",
 				maxWidth: 200,
@@ -26,10 +28,10 @@ export default class extends React.Component {
 				sortable: true,
 				clickable: true
 			},
-			{Header: "Job Count", accessor: "total_job_count", sortable: true},
 			{Header: "When", id: "when", accessor: d => moment(d.start_time).fromNow(), clickable: true, sortable: false},
 			{Header: "Created By", accessor: "created_by", sortable: true},
-			{Header: "Status", accessor: "item_status", sortable: true}
+			{Header: "Activated By", accessor: "activated_by", sortable: true},
+			{Header: "Activated On", id: "activated_date", accessor: d => moment(d.activated_date).format("YYYY-MM-DD HH:mm:ss A"), sortable: true}
 		];
 		return (
 			<div className="slds-color__background_gray-1">

--- a/client/src/upgrades/UpgradeRecord.js
+++ b/client/src/upgrades/UpgradeRecord.js
@@ -96,6 +96,8 @@ export default class extends React.Component {
 					<HeaderField label="Status" value={`${upgrade.status} - ${upgrade.item_status}`} detail={upgrade.comment}/>
 					<HeaderField label="Jobs" value={upgrade.total_job_count}/>
 					<HeaderField label="Created By" value={upgrade.created_by}/>
+					<HeaderField label="Activated By" value={upgrade.activated_by}/>
+					<HeaderField label="Activated On" value={`${moment(upgrade.activated_date).format('lll')}`}/>
 				</RecordHeader>
 				<ProgressBar progressSuccess={progress.percentageSuccess} progressWarning={progress.percentageCanceled}
 							 progressError={progress.percentageError}/>

--- a/client/src/upgrades/UpgradeRecord.js
+++ b/client/src/upgrades/UpgradeRecord.js
@@ -96,8 +96,9 @@ export default class extends React.Component {
 					<HeaderField label="Status" value={`${upgrade.status} - ${upgrade.item_status}`} detail={upgrade.comment}/>
 					<HeaderField label="Jobs" value={upgrade.total_job_count}/>
 					<HeaderField label="Created By" value={upgrade.created_by}/>
-					<HeaderField label="Activated By" value={upgrade.activated_by}/>
-					<HeaderField label="Activated On" value={`${moment(upgrade.activated_date).format('lll')}`}/>
+					<HeaderField label="Activated By" value={upgrade.activated_by || 'Pending'}/>
+					<HeaderField label="Activated On" value={`${upgrade.activated_date ? 
+						moment(upgrade.activated_date).format('lll') : 'Pending'}`}/>
 				</RecordHeader>
 				<ProgressBar progressSuccess={progress.percentageSuccess} progressWarning={progress.percentageCanceled}
 							 progressError={progress.percentageError}/>

--- a/init/sql/init.sql
+++ b/init/sql/init.sql
@@ -87,7 +87,9 @@ create table if not exists upgrade
   parent_id    varchar(18),
   comment      text,
   org_group_id varchar(18),
-  created_by   varchar(255)
+  created_by   varchar(255),
+  activated_by   varchar(255),
+  activated_date  timestamp with time zone
 );
 
 create table if not exists upgrade_blacklist (

--- a/init/sql/migrate.sql
+++ b/init/sql/migrate.sql
@@ -1,7 +1,9 @@
 -- Add any data model changes, data fixes or new indices here.  Can be removed once all deployments are upgraded.
 
 alter table upgrade
-  add if not exists comment text;
+  add if not exists comment text,
+  add if not exists activated_by varchar(255),
+  add if not exists activated_date  timestamp with time zone;
 
 alter table package
   add if not exists status varchar(80);


### PR DESCRIPTION
Add simple audit fields on Upgrade records for who activated an upgrade, and when.

1. Upgrade now has activated_by and activated_date, set when an upgrade is activated.  Existing upgrade records will not be affected.
2. All upgrade lists have activated_by and activated_date added; upgrade record page has activated by and activated on added as well.